### PR TITLE
feat: add Mega-Gorilla/VhubPlaylistViewer to listing

### DIFF
--- a/source.json
+++ b/source.json
@@ -13,7 +13,8 @@
     },
     "bannerUrl": "banner.png",
     "githubRepos": [
-        "Mega-Gorilla/KawaPlayer"
+        "Mega-Gorilla/KawaPlayer",
+        "Mega-Gorilla/VhubPlaylistViewer"
     ],
     "packages": []
 }


### PR DESCRIPTION
## Summary

Closes #1.

`Mega-Gorilla/VhubPlaylistViewer` を listing に追加 (本 listing 2 件目の package、1 件目は既存 KawaPlayer)。

## Diff

```diff
 "githubRepos": [
-    "Mega-Gorilla/KawaPlayer"
+    "Mega-Gorilla/KawaPlayer",
+    "Mega-Gorilla/VhubPlaylistViewer"
 ]
```

## 対象 package

| 項目 | 値 |
|---|---|
| Package id | com.vhub.kawaplayer-playlistviewer |
| Display name | VHub PlaylistViewer |
| Initial release | [v0.1.0 (alpha)](https://github.com/Mega-Gorilla/VhubPlaylistViewer/releases/tag/0.1.0) |
| License | Apache License 2.0 |
| Description | VRChat ワールド内で VHub PlayList のプレイリストを browse して、URL を KawaPlayer 等の動画プレイヤーに渡す View 専用 unitypackage |

## Release `0.1.0` 状態 (build-listing.yml が auto-detect する元)

- ✅ tag `0.1.0` (no v prefix、KawaPlayer 1.0.0 の慣例に揃え)
- ✅ Release assets:
  - `package.json` (root copy)
  - `com.vhub.kawaplayer-playlistviewer-0.1.0.zip` (root flat zip via `git archive`、~2 MB、99 tracked files)

`vrchat-community/package-list-action` がこれら 2 assets を tag/version pair として認識可能。

## Workflow trigger

`build-listing.yml` の `paths: source.json` trigger により、本 PR merge で workflow auto trigger → 数分で `https://mega-gorilla.github.io/vpm-repos/index.json` に反映予定。

## Verification (post-merge)

1. Actions tab で `build-listing` workflow success
2. `curl https://mega-gorilla.github.io/vpm-repos/index.json | jq '.packages | keys'` → `com.vhub.kawaplayer-playlistviewer` 含む
3. VCC > Project > Manage Packages で「VHub PlaylistViewer 0.1.0」表示・install 可能 (user 確認)

## 関連

- 本 listing entry: [com.vhub.kawaplayer-playlistviewer](https://github.com/Mega-Gorilla/VhubPlaylistViewer)
- 連動 issue (本 PR で close): #1
- Package 側 issue: [Mega-Gorilla/VhubPlaylistViewer#17](https://github.com/Mega-Gorilla/VhubPlaylistViewer/issues/17) — VPM listing 登録
- VPM listing 仕様: https://vcc.docs.vrchat.com/vpm/repos